### PR TITLE
has mouth, bounce, and blinks toggles checked by default

### DIFF
--- a/scenes/screen_object_menu.tscn
+++ b/scenes/screen_object_menu.tscn
@@ -62,7 +62,7 @@ horizontal_alignment = 1
 layout_mode = 2
 size_flags_horizontal = 4
 theme = ExtResource("1_dxbbx")
-flat = true
+button_pressed = true
 
 [node name="PanelContainer2" type="PanelContainer" parent="VBoxContainer/Booleans/HBoxContainer"]
 layout_mode = 2
@@ -81,7 +81,7 @@ horizontal_alignment = 1
 layout_mode = 2
 size_flags_horizontal = 4
 theme = ExtResource("1_dxbbx")
-flat = true
+button_pressed = true
 
 [node name="PanelContainer3" type="PanelContainer" parent="VBoxContainer/Booleans/HBoxContainer"]
 layout_mode = 2
@@ -100,7 +100,7 @@ horizontal_alignment = 1
 layout_mode = 2
 size_flags_horizontal = 4
 theme = ExtResource("1_dxbbx")
-flat = true
+button_pressed = true
 
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/Close" to="." method="_delete_object"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/Change Image" to="." method="_request_file"]


### PR DESCRIPTION
In a previous commit I thought I was setting the check boxes to checked by default. Turns out I was just making them hard to see...oops. I should have double checked that before I merged. Today I learned about the importance of code reviews.

It's fixed now.