### PR TITLE
added user_scale scroll to drag targets

### DIFF
--- a/scenes/MicRecord.tscn
+++ b/scenes/MicRecord.tscn
@@ -175,6 +175,7 @@ access = 2
 filters = PackedStringArray("*.png, *.jpg, *.jpeg, *.bmp, *.dds, *.ktx, *.exr, *.hdr, *.tga, *.svg, *.webp")
 use_native_dialog = true
 
+[connection signal="gui_input" from="." to="." method="_on_gui_input"]
 [connection signal="drag_ended" from="Menu/PanelContainer/VBoxContainer/HBoxContainer/ThesholdSlider" to="." method="_on_v_slider_drag_ended"]
 [connection signal="pressed" from="Menu/PanelContainer/VBoxContainer/ScrollContainer/VBoxContainer/Button" to="Menu" method="_create_new_object"]
 [connection signal="button_down" from="Menu/PanelContainer/VBoxContainer/FileButton" to="Menu" method="_on_file_button_button_down"]

--- a/scripts/MicRecord.gd
+++ b/scripts/MicRecord.gd
@@ -6,6 +6,9 @@ const MAX_SAMPLES = 10
 var bus_index
 @onready var menu = %Menu
 
+const SCALE_RATIO = 1.1
+
+
 var is_talking := false:
 	set(value):
 		if value != is_talking:
@@ -51,3 +54,14 @@ func _get_average() -> float:
 
 func _on_v_slider_drag_ended(value_changed):
 	Save.threshold = %ThesholdSlider.value
+
+
+
+func _on_gui_input(event):
+	if event is InputEventMouseButton and menu.drag_target:
+		match event.button_index:
+			MOUSE_BUTTON_WHEEL_UP:
+				menu.drag_target.user_scale *= SCALE_RATIO
+			MOUSE_BUTTON_WHEEL_DOWN:
+				menu.drag_target.user_scale *= 1 / SCALE_RATIO
+	

--- a/scripts/screen_object.gd
+++ b/scripts/screen_object.gd
@@ -19,7 +19,13 @@ var id: String
 	set(value):
 		talking = value
 		create_visual()
-var user_scale: Vector2
+
+var user_scale: Vector2  = Vector2(1, 1) :
+	set(value):
+		if sprite:
+			sprite.scale = value
+			user_scale = value
+
 var user_position: Vector2
 var sprite: Node2D
 var blink_timer: Timer
@@ -77,6 +83,7 @@ func create_talking_atlas():
 	var width = floor(texture.get_width()/2)
 	var height = floor(texture.get_height()/2)
 	sprite = AnimatedSprite2D.new()
+	sprite.scale = user_scale
 	sprite.sprite_frames = SpriteFrames.new()
 	for i in range(4):
 		var atlas_texture = AtlasTexture.new()
@@ -103,6 +110,7 @@ func create_normal_sprite():
 	sprite = Sprite2D.new()
 	sprite.texture = texture
 	sprite.name = "Sprite"
+	sprite.scale = user_scale
 	add_child(sprite)
 
 func generate_animation():


### PR DESCRIPTION
- updated to add a `_on_gui_input` event in the MicRecord scene. This is to detect user scroll as it's the only node available after you pass the main screen.
![image](https://github.com/quellus/GDTuber/assets/59995955/c4b63a99-6664-47f2-9671-f23d720e17f8)

- added a `SCALE_RATIO` constant to increment / decrement when the user scrolls in or out
- added `.scale` to both the `create_talking_atlas` and `create_normal_sprite` this is to make sure the `SCALE_RATIO` is applied when the user clicks one of the three options `HasMouth`, `Bounce` and `Blink` as `create_visual` is called when either one of the options has been selected which `dequeues` the previous sprite and generates a new one.