### PR TITLE
Change project version to a string

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,6 +11,7 @@ config_version=5
 [application]
 
 config/name="GDTuber"
+config/version="0.10.0"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.2")
 run/low_processor_mode=true

--- a/scripts/Menu.gd
+++ b/scripts/Menu.gd
@@ -179,8 +179,8 @@ func _validate_save_json(dict: Dictionary, version: String) -> bool:
 			"background_color":TYPE_STRING
 		}
 	}
-	for v in versions:
-		if v <= version:
+	for v: String in versions:
+		if version.naturalnocasecmp_to(v) >= 0:
 			for field in versions[v]:
 				if field not in dict:
 					push_error("FIELD NOT FOUND: " + field)
@@ -233,7 +233,7 @@ func _validate_object_json(dict: Dictionary, version: String) -> bool:
 		}
 	}
 	for v in versions:
-		if v <= version:
+		if version.naturalnocasecmp_to(v) >= 0:
 			for field in versions[v]:
 				if field not in dict:
 					push_error("FIELD NOT FOUND: " + field)
@@ -260,7 +260,7 @@ func _load_data(path):
 		if _validate_save_json(save_dict, version):
 			version = save_dict["version"]
 			# Version Check
-			if version > project_version:
+			if version.naturalnocasecmp_to(project_version) > 0:
 				push_warning("WARNING: save data is newer than current version, attempting to load data")
 			
 			# Generate Objects from Objects Array
@@ -333,7 +333,7 @@ func _load_data(path):
 			if version.naturalnocasecmp_to("0.4") >= 0:
 				_set_profile_name(save_dict["profile_name"])
 			# 0.8
-			if version.naturalnocasecmp_to("0.8"):
+			if version.naturalnocasecmp_to("0.8") >= 0:
 				background_color = Color.from_string(save_dict["background_color"], background_color)
 				_change_background_color(background_color)
 				bgcolorPicker.color = background_color


### PR DESCRIPTION
Also moved project version into the project settings

 - When loading, we don't care if version number was a float or a string, we just cast to string and treat it the same regardless
 - New save files now have version number as a string
 - Tested with save files from version 0.9 as well as an unmerged change that created a 1.0 save file.
 - Tested by generating a new save file and loading it. No issues found

I don't really like that we had to change a simple `float >= float` comparison to `string.naturalnocasecmp_to(string) >= 0` super hard to read and I had to spend a lot of time just understanding what `naturalnocasecmp_to` does, but as far as I can tell, there isn't a more readable way to compare strings lexicographically in Godot.