### PR TITLE
Add .tmp file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ export_presets.cfg
 .mono/
 data_*/
 mono_crash.*.json
+
+# Those annoying tmp files Godot keeps creating
+*.tmp


### PR DESCRIPTION
Closes #100 

Godot makes those really annoying .tmp files and we don't know why, but what we do know is that we don't want them in the repo so they should be ignored.

The .tmp ignores them now.