### PR TITLE
Fixed little file extension bug

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -407,7 +407,7 @@ use_native_dialog = true
 [node name="JSONSaveDialog" type="FileDialog" parent="."]
 unique_name_in_owner = true
 access = 2
-filters = PackedStringArray("*.json")
+filters = PackedStringArray("*.gdtuber,*.json")
 show_hidden_files = true
 use_native_dialog = true
 
@@ -418,7 +418,7 @@ size = Vector2i(312, 154)
 ok_button_text = "Open"
 file_mode = 0
 access = 2
-filters = PackedStringArray("*.gdtuber", "*.json")
+filters = PackedStringArray("*.gdtuber,*.json")
 show_hidden_files = true
 use_native_dialog = true
 


### PR DESCRIPTION
The loading dialog was filtering out all file types except `.gdtuber`, if you had a `.json` file it required you to select it in the dropdown first. Now they're both selected and you don't have to do anything.

The save dialog only allowed `.json` by default, now it filters both.
