### PR TITLE
Added GDTuber version to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -35,10 +35,17 @@ body:
   - type: input
     id: version
     attributes:
-      label: Godot Version
+      label: GDTuber Version
       placeholder: 1.2.3 (USE AN ACTUAL VERSION NUMBER)
     validations:
       required: true
+  - type: input
+    id: version
+    attributes:
+      label: Godot Version (if running in debug)
+      placeholder: 1.2.3 (USE AN ACTUAL VERSION NUMBER)
+    validations:
+      required: false
   - type: dropdown
     id: platforms
     attributes:


### PR DESCRIPTION
I realized that GDTuber version is far more important than Godot version in the bug report issue template.

- Godot version is an optional field
- We now have a required GDTuber version

We should put a version label somewhere in the UI so people can find the GDTuber version more easily.