### PR TITLE
Change multi-image to the default

### DIFF
--- a/scripts/screen_object.gd
+++ b/scripts/screen_object.gd
@@ -123,7 +123,7 @@ var neutralpath: String
 var talkingpath: String
 var blinkingpath: String
 var talkingandblinkingpath: String
-var usesingleimage: bool = true:
+var usesingleimage: bool = false:
 	set(value):
 		usesingleimage = value
 		create_visual()


### PR DESCRIPTION
Closes #121

I people are far more likely to have multiple images rather than a sprite sheet, so it should just be the default.