### PR TITLE
Changed the screen object popups to a window so we can resize them correctly

### DIFF
--- a/Settings Menu.gd
+++ b/Settings Menu.gd
@@ -34,3 +34,6 @@ class_name ScreenObjectSettingsPopup extends Popup
 @onready var talkingimageselect = %"Talking Image"
 @onready var talkingandblinkingimageselect = %"Talking + Blinking Image"
 @onready var singleimagetoggle = %SingleMultiToggle
+
+@onready var screenobjectname: Label = %ScreenObjectName
+

--- a/Settings Menu.gd
+++ b/Settings Menu.gd
@@ -36,4 +36,3 @@ class_name ScreenObjectSettingsPopup extends Popup
 @onready var singleimagetoggle = %SingleMultiToggle
 
 @onready var screenobjectname: Label = %ScreenObjectName
-

--- a/project.godot
+++ b/project.godot
@@ -33,6 +33,7 @@ WindowManager="*res://scripts/WindowManager.gd"
 window/size/viewport_width=1280
 window/size/viewport_height=720
 window/size/transparent=true
+window/subwindows/embed_subwindows=false
 window/per_pixel_transparency/allowed=true
 window/vsync/vsync_mode=0
 

--- a/scenes/ScreenObjectSettingsPopup.tscn
+++ b/scenes/ScreenObjectSettingsPopup.tscn
@@ -8,58 +8,56 @@
 bg_color = Color(0.290196, 0.290196, 0.290196, 1)
 
 [node name="Popup" type="Popup"]
-size = Vector2i(256, 256)
+size = Vector2i(256, 367)
 visible = true
+min_size = Vector2i(100, 100)
+content_scale_mode = 1
 script = ExtResource("1_ay34f")
 
-[node name="Control" type="Control" parent="."]
-layout_mode = 3
+[node name="PanelContainer" type="PanelContainer" parent="."]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = -111.0
+offset_right = 8.0
+offset_bottom = 111.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 
-[node name="PanelContainer" type="PanelContainer" parent="Control"]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
 layout_mode = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer"]
 layout_mode = 2
+size_flags_vertical = 3
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="ScreenObjectName" type="Label" parent="Control/PanelContainer/VBoxContainer/MarginContainer"]
+[node name="ScreenObjectName" type="Label" parent="PanelContainer/VBoxContainer/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 1
 text = "ScreenObjectName"
 
-[node name="TabContainer" type="TabContainer" parent="Control/PanelContainer/VBoxContainer"]
+[node name="TabContainer" type="TabContainer" parent="PanelContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
+current_tab = 0
 
-[node name="Image" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer"]
+[node name="Image" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer"]
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
+metadata/_tab_index = 0
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image"]
-layout_mode = 2
-vertical_scroll_mode = 2
-
-[node name="MarginContainer" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/margin_left = 20
@@ -67,18 +65,18 @@ theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Combined_Separate" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Combined_Separate" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Combined_Separate"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Combined_Separate"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Reduces hard edges"
@@ -86,22 +84,22 @@ theme_override_font_sizes/font_size = 11
 text = "Combined Avatar Image"
 horizontal_alignment = 1
 
-[node name="SingleMultiToggle" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
+[node name="SingleMultiToggle" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Reduces hard edges"
 theme = ExtResource("2_ves45")
 
-[node name="SelectSingleImage" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="SelectSingleImage" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -109,10 +107,10 @@ theme_override_font_sizes/font_size = 13
 text = "Avatar"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
 layout_mode = 2
 
-[node name="ImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
+[node name="ImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -120,11 +118,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="ImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -132,19 +130,19 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="SelectSeparateImages" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="SelectSeparateImages" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Select Neutral Image" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Select Neutral Image" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -152,10 +150,10 @@ theme_override_font_sizes/font_size = 13
 text = "Neutral Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="NeutralImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
+[node name="NeutralImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -163,11 +161,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="NeutralImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="NeutralImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -175,15 +173,15 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Blinking Image" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Blinking Image" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -191,10 +189,10 @@ theme_override_font_sizes/font_size = 13
 text = "Blinking Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="BlinkingImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="BlinkingImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -202,11 +200,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="BlinkingImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="BlinkingImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -214,15 +212,15 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Talking Image" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Talking Image" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -230,10 +228,10 @@ theme_override_font_sizes/font_size = 13
 text = "Talking Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="TalkingImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
+[node name="TalkingImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -241,11 +239,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TalkingImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="TalkingImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -253,15 +251,15 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Talking + Blinking Image" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Talking + Blinking Image" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -269,10 +267,10 @@ theme_override_font_sizes/font_size = 13
 text = "Talking + Blinking Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="TalkingAndBlinkingImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="TalkingAndBlinkingImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -280,11 +278,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TalkingAndBlinkingImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="TalkingAndBlinkingImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -292,91 +290,93 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Mouth" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Mouth" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Mouth"]
-layout_mode = 2
-
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
 text = "Has Talking Texture"
 horizontal_alignment = 1
 
-[node name="MouthBox" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
+[node name="MouthBox" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Sprite sheet has talking texture"
 theme = ExtResource("2_ves45")
 
-[node name="Blinks" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Blinks" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Blinks"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Blinks"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has blinking texture"
 text = "Has Blinking Texture"
 horizontal_alignment = 1
 
-[node name="BlinkBox" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
+[node name="BlinkBox" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Sprite sheet has blinking texture"
 theme = ExtResource("2_ves45")
 
-[node name="Filter" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
+[node name="Filter" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Filter"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Filter"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Reduces hard edges"
 text = "Linear Filter"
 horizontal_alignment = 1
 
-[node name="FilterBox" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
+[node name="FilterBox" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Reduces hard edges"
 theme = ExtResource("2_ves45")
 
-[node name="Color" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer"]
+[node name="Color" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer"]
 visible = false
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
+metadata/_tab_index = 1
 
-[node name="MarginContainer" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color"]
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color"]
 layout_mode = 2
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer"]
 layout_mode = 2
 
-[node name="Hue" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
+[node name="Hue" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Hue"
 horizontal_alignment = 1
 
-[node name="HueSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
+[node name="HueSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = -0.5
@@ -384,117 +384,118 @@ max_value = 0.5
 step = 0.01
 value = 0.01
 
-[node name="Saturation" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
+[node name="Saturation" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Saturation"
 horizontal_alignment = 1
 
-[node name="SatSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
+[node name="SatSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 2.0
 step = 0.01
 value = 1.0
 
-[node name="Value" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
+[node name="Value" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Value"
 horizontal_alignment = 1
 
-[node name="ValSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
+[node name="ValSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 1.0
 step = 0.01
 value = 0.5
 
-[node name="Alpha" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
+[node name="Alpha" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 visible = false
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Alpha"
 horizontal_alignment = 1
 
-[node name="AlpSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
+[node name="AlpSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 1.0
 step = 0.01
 value = 1.0
 
-[node name="Animation" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer"]
+[node name="Animation" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer"]
 visible = false
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
+metadata/_tab_index = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation"]
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation"]
 layout_mode = 2
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer"]
 layout_mode = 2
 
-[node name="Bounces" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
+[node name="Bounces" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces"]
+[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Bounces on voice activity"
 text = "Animate Object"
 horizontal_alignment = 1
 
-[node name="BounceBox" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
+[node name="BounceBox" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Bounces on voice activity"
 theme = ExtResource("2_ves45")
 
-[node name="Height" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
+[node name="Height" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Height"
 horizontal_alignment = 1
 
-[node name="HeightSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
+[node name="HeightSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 50.0
 value = 5.0
 
-[node name="Speed" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
+[node name="Speed" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Speed"
 horizontal_alignment = 1
 
-[node name="SpeedSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
+[node name="SpeedSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = 0.02

--- a/scenes/ScreenObjectSettingsPopup.tscn
+++ b/scenes/ScreenObjectSettingsPopup.tscn
@@ -10,6 +10,7 @@ bg_color = Color(0.290196, 0.290196, 0.290196, 1)
 [node name="Popup" type="Popup"]
 size = Vector2i(256, 524)
 visible = true
+borderless = false
 content_scale_mode = 2
 content_scale_aspect = 4
 script = ExtResource("1_ay34f")

--- a/scenes/ScreenObjectSettingsPopup.tscn
+++ b/scenes/ScreenObjectSettingsPopup.tscn
@@ -28,33 +28,58 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="TabContainer" type="TabContainer" parent="Control/PanelContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer"]
 layout_mode = 2
 
-[node name="Image" type="MarginContainer" parent="Control/PanelContainer/TabContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="ScrollContainer" type="ScrollContainer" parent="Control/PanelContainer/TabContainer/Image"]
+[node name="ScreenObjectName" type="Label" parent="Control/PanelContainer/VBoxContainer/MarginContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 1
+text = "ScreenObjectName"
+
+[node name="TabContainer" type="TabContainer" parent="Control/PanelContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Image" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 10
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 10
+
+[node name="ScrollContainer" type="ScrollContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image"]
 layout_mode = 2
 horizontal_scroll_mode = 3
 vertical_scroll_mode = 2
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Combined_Separate" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer"]
+[node name="Combined_Separate" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Combined_Separate"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Combined_Separate"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Reduces hard edges"
@@ -62,22 +87,22 @@ theme_override_font_sizes/font_size = 11
 text = "Combined Avatar Image"
 horizontal_alignment = 1
 
-[node name="SingleMultiToggle" type="CheckBox" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
+[node name="SingleMultiToggle" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Reduces hard edges"
 theme = ExtResource("2_ves45")
 
-[node name="SelectSingleImage" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer"]
+[node name="SelectSingleImage" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSingleImage"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -85,10 +110,10 @@ theme_override_font_sizes/font_size = 13
 text = "Avatar"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
 layout_mode = 2
 
-[node name="ImageButton" type="Button" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
+[node name="ImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -96,11 +121,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ImagePreview" type="TextureRect" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="ImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -108,19 +133,19 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="SelectSeparateImages" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer"]
+[node name="SelectSeparateImages" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Select Neutral Image" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Select Neutral Image" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -128,10 +153,10 @@ theme_override_font_sizes/font_size = 13
 text = "Neutral Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="NeutralImageButton" type="Button" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
+[node name="NeutralImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -139,11 +164,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="NeutralImagePreview" type="TextureRect" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="NeutralImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -151,15 +176,15 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Blinking Image" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Blinking Image" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Blinking Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -167,10 +192,10 @@ theme_override_font_sizes/font_size = 13
 text = "Blinking Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="BlinkingImageButton" type="Button" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="BlinkingImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -178,11 +203,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="BlinkingImagePreview" type="TextureRect" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="BlinkingImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -190,15 +215,15 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Talking Image" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Talking Image" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -206,10 +231,10 @@ theme_override_font_sizes/font_size = 13
 text = "Talking Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="TalkingImageButton" type="Button" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
+[node name="TalkingImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -217,11 +242,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TalkingImagePreview" type="TextureRect" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="TalkingImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -229,15 +254,15 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Talking + Blinking Image" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Talking + Blinking Image" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -245,10 +270,10 @@ theme_override_font_sizes/font_size = 13
 text = "Talking + Blinking Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="TalkingAndBlinkingImageButton" type="Button" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="TalkingAndBlinkingImageButton" type="Button" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -256,11 +281,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TalkingAndBlinkingImagePreview" type="TextureRect" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="TalkingAndBlinkingImagePreview" type="TextureRect" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -268,64 +293,64 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Mouth" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer"]
+[node name="Mouth" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Mouth"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Mouth"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Mouth/HBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
 text = "Has Talking Texture"
 horizontal_alignment = 1
 
-[node name="MouthBox" type="CheckBox" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Mouth/HBoxContainer"]
+[node name="MouthBox" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Sprite sheet has talking texture"
 theme = ExtResource("2_ves45")
 
-[node name="Blinks" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer"]
+[node name="Blinks" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Blinks"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Blinks"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Blinks/HBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has blinking texture"
 text = "Has Blinking Texture"
 horizontal_alignment = 1
 
-[node name="BlinkBox" type="CheckBox" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Blinks/HBoxContainer"]
+[node name="BlinkBox" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Sprite sheet has blinking texture"
 theme = ExtResource("2_ves45")
 
-[node name="Filter" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer"]
+[node name="Filter" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Filter"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Filter"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Filter/HBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Reduces hard edges"
 text = "Linear Filter"
 horizontal_alignment = 1
 
-[node name="FilterBox" type="CheckBox" parent="Control/PanelContainer/TabContainer/Image/ScrollContainer/VBoxContainer/Filter/HBoxContainer"]
+[node name="FilterBox" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Reduces hard edges"
 theme = ExtResource("2_ves45")
 
-[node name="Color" type="MarginContainer" parent="Control/PanelContainer/TabContainer"]
+[node name="Color" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer"]
 visible = false
 layout_mode = 2
 theme_override_constants/margin_left = 10
@@ -333,19 +358,26 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Color"]
+[node name="MarginContainer" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color"]
+layout_mode = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer"]
 layout_mode = 2
 
-[node name="Hue" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer"]
+[node name="Hue" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer/Hue"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Hue"
 horizontal_alignment = 1
 
-[node name="HueSlider" type="HSlider" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer/Hue"]
+[node name="HueSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = -0.5
@@ -353,56 +385,56 @@ max_value = 0.5
 step = 0.01
 value = 0.01
 
-[node name="Saturation" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer"]
+[node name="Saturation" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer/Saturation"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Saturation"
 horizontal_alignment = 1
 
-[node name="SatSlider" type="HSlider" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer/Saturation"]
+[node name="SatSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 2.0
 step = 0.01
 value = 1.0
 
-[node name="Value" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer"]
+[node name="Value" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer/Value"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Value"
 horizontal_alignment = 1
 
-[node name="ValSlider" type="HSlider" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer/Value"]
+[node name="ValSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 1.0
 step = 0.01
 value = 0.5
 
-[node name="Alpha" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer"]
+[node name="Alpha" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 visible = false
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer/Alpha"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Alpha"
 horizontal_alignment = 1
 
-[node name="AlpSlider" type="HSlider" parent="Control/PanelContainer/TabContainer/Color/VBoxContainer/Alpha"]
+[node name="AlpSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 1.0
 step = 0.01
 value = 1.0
 
-[node name="Animation" type="MarginContainer" parent="Control/PanelContainer/TabContainer"]
+[node name="Animation" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer"]
 visible = false
 layout_mode = 2
 theme_override_constants/margin_left = 10
@@ -410,53 +442,60 @@ theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Animation"]
+[node name="MarginContainer" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation"]
+layout_mode = 2
+theme_override_constants/margin_left = 20
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 20
+theme_override_constants/margin_bottom = 20
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer"]
 layout_mode = 2
 
-[node name="Bounces" type="PanelContainer" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer"]
+[node name="Bounces" type="PanelContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer/Bounces"]
+[node name="HBoxContainer" type="HBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer/Bounces/HBoxContainer"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Bounces on voice activity"
 text = "Animate Object"
 horizontal_alignment = 1
 
-[node name="BounceBox" type="CheckBox" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer/Bounces/HBoxContainer"]
+[node name="BounceBox" type="CheckBox" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Bounces on voice activity"
 theme = ExtResource("2_ves45")
 
-[node name="Height" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer"]
+[node name="Height" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer/Height"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Height"
 horizontal_alignment = 1
 
-[node name="HeightSlider" type="HSlider" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer/Height"]
+[node name="HeightSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 50.0
 value = 5.0
 
-[node name="Speed" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer"]
+[node name="Speed" type="VBoxContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer/Speed"]
+[node name="Label" type="Label" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Speed"
 horizontal_alignment = 1
 
-[node name="SpeedSlider" type="HSlider" parent="Control/PanelContainer/TabContainer/Animation/VBoxContainer/Speed"]
+[node name="SpeedSlider" type="HSlider" parent="Control/PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = 0.02

--- a/scenes/ScreenObjectSettingsPopup.tscn
+++ b/scenes/ScreenObjectSettingsPopup.tscn
@@ -35,6 +35,7 @@ layout_mode = 2
 text = "ScreenObjectName"
 
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
+custom_minimum_size = Vector2(250, 0)
 layout_mode = 2
 size_flags_vertical = 3
 current_tab = 0
@@ -282,7 +283,6 @@ stretch_mode = 5
 
 [node name="Mouth" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 layout_mode = 2
-size_flags_vertical = 3
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth"]
 layout_mode = 2

--- a/scenes/ScreenObjectSettingsPopup.tscn
+++ b/scenes/ScreenObjectSettingsPopup.tscn
@@ -57,7 +57,6 @@ theme_override_constants/margin_bottom = 10
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image"]
 layout_mode = 2
-horizontal_scroll_mode = 3
 vertical_scroll_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Control/PanelContainer/VBoxContainer/TabContainer/Image/ScrollContainer"]

--- a/scenes/ScreenObjectSettingsPopup.tscn
+++ b/scenes/ScreenObjectSettingsPopup.tscn
@@ -8,48 +8,38 @@
 bg_color = Color(0.290196, 0.290196, 0.290196, 1)
 
 [node name="Popup" type="Popup"]
-size = Vector2i(256, 367)
+size = Vector2i(256, 524)
 visible = true
-min_size = Vector2i(100, 100)
-content_scale_mode = 1
+content_scale_mode = 2
+content_scale_aspect = 4
 script = ExtResource("1_ay34f")
 
-[node name="PanelContainer" type="PanelContainer" parent="."]
-anchors_preset = 15
-anchor_right = 1.0
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchors_preset = 9
 anchor_bottom = 1.0
-offset_left = 8.0
-offset_top = -111.0
-offset_right = 8.0
-offset_bottom = 111.0
-grow_horizontal = 2
+offset_right = 240.0
 grow_vertical = 2
-size_flags_horizontal = 3
 size_flags_vertical = 3
+theme_override_constants/separation = 5
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
-
-[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer"]
-layout_mode = 2
-size_flags_vertical = 3
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 
-[node name="ScreenObjectName" type="Label" parent="PanelContainer/VBoxContainer/MarginContainer"]
+[node name="ScreenObjectName" type="Label" parent="VBoxContainer/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-size_flags_vertical = 1
 text = "ScreenObjectName"
 
-[node name="TabContainer" type="TabContainer" parent="PanelContainer/VBoxContainer"]
+[node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 current_tab = 0
 
-[node name="Image" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer"]
+[node name="Image" type="MarginContainer" parent="VBoxContainer/TabContainer"]
 layout_mode = 2
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
@@ -57,7 +47,7 @@ theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 metadata/_tab_index = 0
 
-[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image"]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TabContainer/Image"]
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/margin_left = 20
@@ -65,18 +55,18 @@ theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[node name="Combined_Separate" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
+[node name="Combined_Separate" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Combined_Separate"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Combined_Separate"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Reduces hard edges"
@@ -84,22 +74,22 @@ theme_override_font_sizes/font_size = 11
 text = "Combined Avatar Image"
 horizontal_alignment = 1
 
-[node name="SingleMultiToggle" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
+[node name="SingleMultiToggle" type="CheckBox" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Combined_Separate/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Reduces hard edges"
 theme = ExtResource("2_ves45")
 
-[node name="SelectSingleImage" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
+[node name="SelectSingleImage" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -107,10 +97,10 @@ theme_override_font_sizes/font_size = 13
 text = "Avatar"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer"]
 layout_mode = 2
 
-[node name="ImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
+[node name="ImageButton" type="Button" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -118,11 +108,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="ImagePreview" type="TextureRect" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSingleImage/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -130,19 +120,19 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="SelectSeparateImages" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
+[node name="SelectSeparateImages" type="VBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 
-[node name="Select Neutral Image" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Select Neutral Image" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -150,10 +140,10 @@ theme_override_font_sizes/font_size = 13
 text = "Neutral Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="NeutralImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
+[node name="NeutralImageButton" type="Button" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -161,11 +151,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="NeutralImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="NeutralImagePreview" type="TextureRect" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Select Neutral Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -173,15 +163,15 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Blinking Image" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Blinking Image" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -189,10 +179,10 @@ theme_override_font_sizes/font_size = 13
 text = "Blinking Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="BlinkingImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="BlinkingImageButton" type="Button" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -200,11 +190,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="BlinkingImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="BlinkingImagePreview" type="TextureRect" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -212,15 +202,15 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Talking Image" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Talking Image" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -228,10 +218,10 @@ theme_override_font_sizes/font_size = 13
 text = "Talking Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="TalkingImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
+[node name="TalkingImageButton" type="Button" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -239,11 +229,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TalkingImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="TalkingImagePreview" type="TextureRect" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -251,15 +241,15 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Talking + Blinking Image" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
+[node name="Talking + Blinking Image" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_88shl")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
@@ -267,10 +257,10 @@ theme_override_font_sizes/font_size = 13
 text = "Talking + Blinking Image"
 horizontal_alignment = 1
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer"]
 layout_mode = 2
 
-[node name="TalkingAndBlinkingImageButton" type="Button" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="TalkingAndBlinkingImageButton" type="Button" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
@@ -278,11 +268,11 @@ size_flags_horizontal = 3
 theme = ExtResource("2_ves45")
 text = "Change Image"
 
-[node name="PanelContainer" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
+[node name="PanelContainer" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="TalkingAndBlinkingImagePreview" type="TextureRect" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
+[node name="TalkingAndBlinkingImagePreview" type="TextureRect" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/SelectSeparateImages/Talking + Blinking Image/VBoxContainer/HBoxContainer/PanelContainer"]
 unique_name_in_owner = true
 custom_minimum_size = Vector2(0, 32)
 layout_mode = 2
@@ -290,65 +280,65 @@ texture = ExtResource("3_db3l8")
 expand_mode = 2
 stretch_mode = 5
 
-[node name="Mouth" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
+[node name="Mouth" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has talking texture"
 text = "Has Talking Texture"
 horizontal_alignment = 1
 
-[node name="MouthBox" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
+[node name="MouthBox" type="CheckBox" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Mouth/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Sprite sheet has talking texture"
 theme = ExtResource("2_ves45")
 
-[node name="Blinks" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
+[node name="Blinks" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Blinks"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Blinks"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Sprite sheet has blinking texture"
 text = "Has Blinking Texture"
 horizontal_alignment = 1
 
-[node name="BlinkBox" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
+[node name="BlinkBox" type="CheckBox" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Blinks/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Sprite sheet has blinking texture"
 theme = ExtResource("2_ves45")
 
-[node name="Filter" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
+[node name="Filter" type="PanelContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Filter"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Filter"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Reduces hard edges"
 text = "Linear Filter"
 horizontal_alignment = 1
 
-[node name="FilterBox" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
+[node name="FilterBox" type="CheckBox" parent="VBoxContainer/TabContainer/Image/MarginContainer/VBoxContainer/Filter/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Reduces hard edges"
 theme = ExtResource("2_ves45")
 
-[node name="Color" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer"]
+[node name="Color" type="MarginContainer" parent="VBoxContainer/TabContainer"]
 visible = false
 layout_mode = 2
 theme_override_constants/margin_left = 10
@@ -357,26 +347,26 @@ theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 metadata/_tab_index = 1
 
-[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color"]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TabContainer/Color"]
 layout_mode = 2
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Color/MarginContainer"]
 layout_mode = 2
 
-[node name="Hue" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
+[node name="Hue" type="VBoxContainer" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Hue"
 horizontal_alignment = 1
 
-[node name="HueSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
+[node name="HueSlider" type="HSlider" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Hue"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = -0.5
@@ -384,56 +374,56 @@ max_value = 0.5
 step = 0.01
 value = 0.01
 
-[node name="Saturation" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
+[node name="Saturation" type="VBoxContainer" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Saturation"
 horizontal_alignment = 1
 
-[node name="SatSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
+[node name="SatSlider" type="HSlider" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Saturation"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 2.0
 step = 0.01
 value = 1.0
 
-[node name="Value" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
+[node name="Value" type="VBoxContainer" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Value"
 horizontal_alignment = 1
 
-[node name="ValSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
+[node name="ValSlider" type="HSlider" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Value"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 1.0
 step = 0.01
 value = 0.5
 
-[node name="Alpha" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
+[node name="Alpha" type="VBoxContainer" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer"]
 visible = false
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Alpha"
 horizontal_alignment = 1
 
-[node name="AlpSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
+[node name="AlpSlider" type="HSlider" parent="VBoxContainer/TabContainer/Color/MarginContainer/VBoxContainer/Alpha"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 1.0
 step = 0.01
 value = 1.0
 
-[node name="Animation" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer"]
+[node name="Animation" type="MarginContainer" parent="VBoxContainer/TabContainer"]
 visible = false
 layout_mode = 2
 theme_override_constants/margin_left = 10
@@ -442,60 +432,60 @@ theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
 metadata/_tab_index = 2
 
-[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation"]
+[node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TabContainer/Animation"]
 layout_mode = 2
 theme_override_constants/margin_left = 20
 theme_override_constants/margin_top = 20
 theme_override_constants/margin_right = 20
 theme_override_constants/margin_bottom = 20
 
-[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer"]
+[node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/TabContainer/Animation/MarginContainer"]
 layout_mode = 2
 
-[node name="Bounces" type="PanelContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
+[node name="Bounces" type="PanelContainer" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces"]
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "Bounces on voice activity"
 text = "Animate Object"
 horizontal_alignment = 1
 
-[node name="BounceBox" type="CheckBox" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
+[node name="BounceBox" type="CheckBox" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Bounces/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
 tooltip_text = "Bounces on voice activity"
 theme = ExtResource("2_ves45")
 
-[node name="Height" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
+[node name="Height" type="VBoxContainer" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Height"
 horizontal_alignment = 1
 
-[node name="HeightSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
+[node name="HeightSlider" type="HSlider" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Height"]
 unique_name_in_owner = true
 layout_mode = 2
 max_value = 50.0
 value = 5.0
 
-[node name="Speed" type="VBoxContainer" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
+[node name="Speed" type="VBoxContainer" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer"]
 layout_mode = 2
 
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 13
 text = "Speed"
 horizontal_alignment = 1
 
-[node name="SpeedSlider" type="HSlider" parent="PanelContainer/VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
+[node name="SpeedSlider" type="HSlider" parent="VBoxContainer/TabContainer/Animation/MarginContainer/VBoxContainer/Speed"]
 unique_name_in_owner = true
 layout_mode = 2
 min_value = 0.02

--- a/scripts/screen_object_menu.gd
+++ b/scripts/screen_object_menu.gd
@@ -29,15 +29,13 @@ func _ready():
 	settingsmenu.heightslider.value_changed.connect(_set_height)
 	settingsmenu.speedslider.value_changed.connect(_set_speed)
 
-	settingsmenu.togglemultiimage.connect(_toggle_multi_image)	
+	settingsmenu.togglemultiimage.connect(_toggle_multi_image)
 
 	settingsmenu.requestimage.connect(_request_image)
 	settingsmenu.requestneutral.connect(_request_neutral)
 	settingsmenu.requestblinking.connect(_request_blinking)
 	settingsmenu.requesttalking.connect(_request_talking)
 	settingsmenu.requesttalkingandblinking.connect(_request_talking_and_blinking)
-	
-	
 
 func _toggle_multi_image(value):
 	object.usesingleimage = value
@@ -72,8 +70,7 @@ func _open_menu():
 	var width = windowssize.x / 3
 	if(width < 300):
 		width = 300
-	popuprect.size = Vector2(width, windowssize.y)
-	
+	popuprect.size = Vector2(width, windowssize.y)	
 	settingsmenu.popup_on_parent(popuprect)
 
 

--- a/scripts/screen_object_menu.gd
+++ b/scripts/screen_object_menu.gd
@@ -66,11 +66,11 @@ func _request_gizmo():
 
 func _open_menu():
 	var popuprect = popupanchor.get_global_rect()
-	var windowssize =  DisplayServer.window_get_size()
-	var width = windowssize.x / 3
-	if(width < 300):
-		width = 300
-	popuprect.size = Vector2(width, windowssize.y)	
+	#var windowssize =  DisplayServer.window_get_size()
+	#var width = windowssize.x / 3
+	#if(width < 300):
+		#width = 300
+	#popuprect.size = Vector2(width, windowssize.y)
 	settingsmenu.popup_on_parent(popuprect)
 
 

--- a/scripts/screen_object_menu.gd
+++ b/scripts/screen_object_menu.gd
@@ -29,13 +29,15 @@ func _ready():
 	settingsmenu.heightslider.value_changed.connect(_set_height)
 	settingsmenu.speedslider.value_changed.connect(_set_speed)
 
-	settingsmenu.togglemultiimage.connect(_toggle_multi_image)
+	settingsmenu.togglemultiimage.connect(_toggle_multi_image)	
 
 	settingsmenu.requestimage.connect(_request_image)
 	settingsmenu.requestneutral.connect(_request_neutral)
 	settingsmenu.requestblinking.connect(_request_blinking)
 	settingsmenu.requesttalking.connect(_request_talking)
 	settingsmenu.requesttalkingandblinking.connect(_request_talking_and_blinking)
+	
+	
 
 func _toggle_multi_image(value):
 	object.usesingleimage = value
@@ -66,7 +68,12 @@ func _request_gizmo():
 
 func _open_menu():
 	var popuprect = popupanchor.get_global_rect()
-	popuprect.size = Vector2(256, 256)
+	var windowssize =  DisplayServer.window_get_size()
+	var width = windowssize.x / 3
+	if(width < 300):
+		width = 300
+	popuprect.size = Vector2(width, windowssize.y)
+	
 	settingsmenu.popup_on_parent(popuprect)
 
 
@@ -113,6 +120,7 @@ func update_menu():
 		settingsmenu.talkingpreview.texture = object.talking_texture
 		settingsmenu.talkingandblinkingpreview.texture = object.talking_and_blinking_texture
 		settingsmenu.singleimagetoggle.button_pressed = object.usesingleimage
+		settingsmenu.screenobjectname.text = object.user_name
 
 func _shift_up():
 	get_parent().move_child(self, get_index()-1)

--- a/scripts/screen_object_menu.gd
+++ b/scripts/screen_object_menu.gd
@@ -65,14 +65,8 @@ func _request_gizmo():
 
 
 func _open_menu():
-	var popuprect = popupanchor.get_global_rect()
-	#var windowssize =  DisplayServer.window_get_size()
-	#var width = windowssize.x / 3
-	#if(width < 300):
-		#width = 300
-	#popuprect.size = Vector2(width, windowssize.y)
+	var popuprect: Rect2 = popupanchor.get_global_rect()
 	settingsmenu.popup_on_parent(popuprect)
-
 
 func _set_blinks(value):
 	object.blinking = value


### PR DESCRIPTION
Closes #98

- Screen object popups are exactly the size of their contents
- They're also windows now because I couldn't find a better way to stop them from going off screen