### PR TITLE
0.11.0

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="GDTuber"
-config/version="0.10.0"
+config/version="0.11.0"
 run/main_scene="res://scenes/Main.tscn"
 config/features=PackedStringArray("4.3")
 run/low_processor_mode=true
@@ -44,3 +44,4 @@ project/assembly_name="GDTuber"
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
+textures/vram_compression/import_etc2_astc=true

--- a/scenes/ScreenObjectSettingsPopup.tscn
+++ b/scenes/ScreenObjectSettingsPopup.tscn
@@ -30,6 +30,7 @@ grow_vertical = 2
 
 [node name="TabContainer" type="TabContainer" parent="Control/PanelContainer"]
 layout_mode = 2
+current_tab = 0
 
 [node name="Image" type="MarginContainer" parent="Control/PanelContainer/TabContainer"]
 layout_mode = 2
@@ -37,6 +38,7 @@ theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
+metadata/_tab_index = 0
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Control/PanelContainer/TabContainer/Image"]
 layout_mode = 2
@@ -332,6 +334,7 @@ theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
+metadata/_tab_index = 1
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Color"]
 layout_mode = 2
@@ -409,6 +412,7 @@ theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 10
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 10
+metadata/_tab_index = 2
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Control/PanelContainer/TabContainer/Animation"]
 layout_mode = 2


### PR DESCRIPTION
 - Bumped version number
 - Little change to project settings required for Mac exports on Godot 4.3
 - Godot made some changes to [ScreenObjectSettingsPopup.tscn](https://github.com/quellus/GDTuber/compare/0.0.11?expand=1#diff-6a5dbfce497be253c09383f73ef97ca4a537a69766594089cd1848a3ceb3e3c6) because of the 4.3 update