### PR TITLE
Add FPS Cap

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -384,6 +384,56 @@ max_value = 5000.0
 value = 800.0
 alignment = 1
 
+[node name="FPS" type="PanelContainer" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems"]
+layout_mode = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS"]
+layout_mode = 2
+theme_override_constants/margin_left = 5
+theme_override_constants/margin_top = 5
+theme_override_constants/margin_right = 5
+theme_override_constants/margin_bottom = 5
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer"]
+layout_mode = 2
+
+[node name="CurrentFPSLabel" type="Label" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "Current FPS:"
+
+[node name="FPSCapContainer" type="HBoxContainer" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer/VBoxContainer"]
+layout_mode = 2
+
+[node name="FPSCapLabel" type="Label" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer/VBoxContainer/FPSCapContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Cap FPS"
+
+[node name="FPSCapToggle" type="CheckBox" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer/VBoxContainer/FPSCapContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme = ExtResource("3_5cu1w")
+
+[node name="FPSDropdownContainer" type="HBoxContainer" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+
+[node name="MaxFPSLabel" type="Label" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer/VBoxContainer/FPSDropdownContainer"]
+layout_mode = 2
+text = "FPS: "
+
+[node name="MaxFPSSpinbox" type="SpinBox" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer/VBoxContainer/FPSDropdownContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+min_value = 15.0
+max_value = 500.0
+value = 60.0
+rounded = true
+allow_greater = true
+
 [node name="BottomMenuItems" type="VBoxContainer" parent="Menu/PanelContainer/SettingsMenu/VBoxContainer2"]
 layout_mode = 2
 size_flags_vertical = 3
@@ -463,6 +513,8 @@ autostart = true
 [connection signal="toggled" from="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/Fixed Window Size/HBoxContainer/CenterContainer/FixedWindowSizeToggle" to="." method="_on_fixed_window_button_toggled"]
 [connection signal="value_changed" from="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/WindowSize/VBoxContainer/HBoxContainer2/CenterContainer/fixedWindowWidthSpinbox" to="." method="_on_ws_lock_width_value_changed"]
 [connection signal="value_changed" from="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/WindowSize/VBoxContainer/HBoxContainer3/CenterContainer2/fixedWindowHeightSpinbox" to="." method="_on_ws_lock_height_value_changed"]
+[connection signal="toggled" from="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer/VBoxContainer/FPSCapContainer/FPSCapToggle" to="." method="_on_fps_cap_toggled"]
+[connection signal="value_changed" from="Menu/PanelContainer/SettingsMenu/VBoxContainer2/TopMenuItems/FPS/MarginContainer/VBoxContainer/FPSDropdownContainer/MaxFPSSpinbox" to="." method="_on_max_fps_spinbox_value_changed"]
 [connection signal="pressed" from="Menu/PanelContainer/SettingsMenu/VBoxContainer2/BottomMenuItems/QuitButton" to="." method="_on_quit_button_button_down"]
 [connection signal="button_down" from="Menu/Gizmo/Button" to="Menu/Gizmo" method="drag"]
 [connection signal="button_up" from="Menu/Gizmo/Button" to="Menu/Gizmo" method="dragnt"]

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -26,6 +26,10 @@ var menu_shown = false:
 	set(value):
 		menu_shown = value
 		_set_menu_shown(value)
+@onready var fpsCapToggle = %FPSCapToggle
+@onready var maxFpsSpinbox = %MaxFPSSpinbox
+@onready var fpsCap: bool = false
+@onready var fpsCapValue: int = 0
 
 # Audio Management
 const MAX_SAMPLES = 20
@@ -115,6 +119,8 @@ func _process(_delta):
 			is_talking = false
 
 	%VolumeVisual.value = magnitude_avg
+	
+	%CurrentFPSLabel.set_text("Current FPS %.1f" % Engine.get_frames_per_second())
 
 func _notification(what):
 	if what == NOTIFICATION_WM_CLOSE_REQUEST:
@@ -171,6 +177,8 @@ func _save_profile_data():
 		"fixedWindowWidth":fixedWindowWidth,
 		"fixedWindowHeight":fixedWindowHeight,
 		"fixedWindowSize":fixedWindowSize,
+		"fpsCap": fpsCap,
+		"fpsCapValue": fpsCapValue,
 		"objects":[]
 	}
 	for obj in ObjectsRoot.get_children():
@@ -218,7 +226,9 @@ func _validate_save_json(dict: Dictionary, version: String) -> bool:
 		"0.10":{
 			"fixedWindowHeight":TYPE_INT,
 			"fixedWindowWidth": TYPE_INT,
-			"fixedWindowSize":TYPE_BOOL
+			"fixedWindowSize":TYPE_BOOL,
+			"fpsCap": TYPE_BOOL,
+			"fpsCapValue": TYPE_INT
 		}
 	}
 	for v: String in versions:
@@ -380,6 +390,8 @@ func _load_data(path):
 				fixedWindowSizeToggle.button_pressed = save_dict["fixedWindowSize"]
 				fixedWindowWidthSpinbox.value = save_dict["fixedWindowWidth"]
 				fixedWindowHeightSpinbox.value = save_dict["fixedWindowHeight"]
+				maxFpsSpinbox.set_value_no_signal(save_dict["fpsCapValue"] if save_dict["fpsCap"] else 60)
+				fpsCapToggle.set_pressed(save_dict["fpsCap"])
 		else:
 			push_error("ERROR: Required Fields for Save File Version not Found")
 	else:
@@ -608,3 +620,19 @@ func _unhandled_input(event):
 	if event is InputEventKey or event is InputEventMouse:
 		if event.is_pressed():
 			menu_shown = true
+
+
+func _on_fps_cap_toggled(toggled_on: bool) -> void:
+	fpsCap = toggled_on
+	if not toggled_on:
+		%FPSDropdownContainer.hide()
+		Engine.set_max_fps(0)
+		return
+	
+	%FPSDropdownContainer.show()
+	_on_max_fps_spinbox_value_changed(%MaxFPSSpinbox.get_value())
+
+func _on_max_fps_spinbox_value_changed(value: float) -> void:
+	fpsCapValue = int(value)
+	if int(value)!= Engine.get_max_fps():
+		Engine.set_max_fps(int(value))


### PR DESCRIPTION
This PR adds an FPS cap feature. 

By default, GDTuber will run with an uncapped FPS. This can cause performance issues, especially for slower PCs. Limiting the app's FPS can alleviate these issues.

Note: Changing the max FPS affects *ALL* aspects of the app, not just the avatar animations! This includes the audio processing and app responsiveness. As a result, the `MaxFPSSpinbox` node has a minimum value of 15. This value can be changed, and we can add another validation check in the `_on_max_fps_spinbox_value_changed` method if needed.

![gdtuber_fps_cap](https://github.com/user-attachments/assets/d7b21a28-6f56-419b-a8a2-bdefe83e05cd)
