### PR TITLE
Remove default controller inputs

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -40,6 +40,34 @@ window/vsync/vsync_mode=0
 
 project/assembly_name="GDTuber"
 
+[input]
+
+ui_select={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":32,"physical_keycode":0,"key_label":0,"unicode":32,"location":0,"echo":false,"script":null)
+]
+}
+ui_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194319,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+ui_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194321,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+ui_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194320,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+ui_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194322,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
+
 [internationalization]
 
 locale/translations=PackedStringArray("res://Translations/English.en.translation")


### PR DESCRIPTION
This closes #156
In summary, the problem I'm trying to solve is that controller inputs navigate GDTuber's menus and make changes to things even when the window is not focused. This means, as I use a controller, I am accidentally navigating menus and making changes to the microphone threshold and gain.

Before I started looking into this issue, I was really hoping to find a way to keep controller support working and disable it only while the window isn't focused. I was also operating on the assumption that controller support was working well as it is.

In reality, I discovered that Godot doesn't have a good solution to this problem. We would have to completely reimplement the input handling and write scripts that control every individual button/slider. A pretty daunting task. Controller support as it is now, does not work well. Most of GDTuber's functionality is inaccessible via controller.

So with all this in mind, the most logical solution is to completely remove controller support. It doesn't work well and creates more problems than it can solve.