### PR TITLE
Fixed wiki action claiming no updates to wiki when there were, in fact, updates

### DIFF
--- a/.github/workflows/publish_docs_to_wiki.yml
+++ b/.github/workflows/publish_docs_to_wiki.yml
@@ -31,7 +31,7 @@ jobs:
           git pull https://$USER_TOKEN@github.com/$OWNER/$REPOSITORY_NAME.wiki.git
       - name: Push content to wiki
         run: |
-          rsync -av --delete wiki/ tmp_wiki/ --exclude .git
+          rsync --checksum -av --delete wiki/ tmp_wiki/ --exclude .git
           cd tmp_wiki
           git add .
           git commit -m "Update Wiki content" 


### PR DESCRIPTION
The GitHub action is failing to update the wiki.

Our understanding of why this happened is that the `rsync` command was only recognizing file changes when the file *size* was changed. I managed to find a weird corner case with my most recent change to `Contributing.md`. I the changed contents of the file without changing the size of the file.

Adding the `--checksum` flag solves this issue by having the `rsync` command compare checksums instead.