### PR TITLE
Added timer to regularly reset audio device

### DIFF
--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -521,6 +521,10 @@ use_native_dialog = true
 wait_time = 60.0
 autostart = true
 
+[node name="AudioResetTimer" type="Timer" parent="."]
+wait_time = 60.0
+autostart = true
+
 [connection signal="text_submitted" from="Menu/PanelContainer/MainMenu/TitleEdit" to="." method="_set_profile_name"]
 [connection signal="value_changed" from="Menu/PanelContainer/MainMenu/HBoxContainer/ThresholdSlider" to="." method="_on_v_slider_drag_ended"]
 [connection signal="value_changed" from="Menu/PanelContainer/MainMenu/HBoxContainer/InputGainSlider" to="." method="_on_input_gain_change"]
@@ -544,3 +548,4 @@ autostart = true
 [connection signal="file_selected" from="JSONSaveDialog" to="." method="_save_file"]
 [connection signal="file_selected" from="JSONLoadDialog" to="." method="_load_data"]
 [connection signal="timeout" from="AutosaveTimer" to="." method="_on_autosave_timer_timeout"]
+[connection signal="timeout" from="AudioResetTimer" to="." method="_on_audio_reset_timer_timeout"]

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -337,3 +337,12 @@ func _on_max_fps_spinbox_value_changed(value: float) -> void:
 	fps_cap_value = int(value)
 	if int(value) != Engine.get_max_fps():
 		Engine.set_max_fps(int(value))
+
+
+func _on_audio_reset_timer_timeout() -> void:
+	print_debug("Resetting audio device")
+	var orig_device = AudioServer.input_device
+	var devices = AudioServer.get_input_device_list()
+	AudioServer.input_device = devices[randi() % devices.size()]
+	await get_tree().create_timer(0.2).timeout
+	AudioServer.input_device = orig_device

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -343,6 +343,8 @@ func _on_audio_reset_timer_timeout() -> void:
 	print_debug("Resetting audio device")
 	var orig_device = AudioServer.input_device
 	var devices = AudioServer.get_input_device_list()
-	AudioServer.input_device = devices[randi() % devices.size()]
+	var index = devices.find(orig_device)
+	var rand_index = (index + randi_range(1, devices.size() - 1)) % devices.size()
+	AudioServer.input_device = devices[rand_index]
 	await get_tree().create_timer(0.2).timeout
 	AudioServer.input_device = orig_device


### PR DESCRIPTION
This is a controversial change, because it's a fairly naive band-aid.

We've been struggling to diagnose why, for some users, GDTuber will start accumulating latency between when sound is made in the microphone, and when it reacts to the sound. In most cases that I've seen so far, it seems to accumulate over about 30 minutes and becomes unbearable after an hour or more.
I found that the latency will get reset if I change the audio device, then quickly change it back. So I implemented this solution where every minute, it will automatically change the device to a random audio device then change it back.

### Why this isn't an ideal solution
 - There may be a better solution if we can dig in and find the root cause of this problem. Is it a bug in Godot's audio engine?
 - Some users may only have 1 audio device. This solution will not solve their problem.

### Why I think we should do it anyway
 - This problem is very significant. Users of GDTuber stream for hours, and GDTuber is often their main form of branding.
 - We have no leads into the root cause of this problem. This is currently the only solution we have.
 - This issue is a huge problem for the people it effects and a solution should be implemented sooner rather than later.

