### PR TITLE
Fixed translation import settings

### DIFF
--- a/Translations/Brazilian Portuguese.csv.import
+++ b/Translations/Brazilian Portuguese.csv.import
@@ -3,11 +3,13 @@
 importer="csv_translation"
 type="Translation"
 uid="uid://dkm2agnlbu52s"
-valid=false
 
 [deps]
 
+files=["res://Translations/Brazilian Portuguese.pt_BR.translation"]
+
 source_file="res://Translations/Brazilian Portuguese.csv"
+dest_files=["res://Translations/Brazilian Portuguese.pt_BR.translation"]
 
 [params]
 


### PR DESCRIPTION
Translation files weren't importing properly and through an error to the console. Forcing a reimport caused Godot to generate this change. After making this change, Godot is able to happily import translation files without error.